### PR TITLE
Aligning event2rdf with ontology

### DIFF
--- a/docs/docker-engine-events/events.owl
+++ b/docs/docker-engine-events/events.owl
@@ -4,8 +4,8 @@
 @prefix dockevent: <http://ontology.aksw.org/dockevent/> .
 @prefix dockevent_types: <http://ontology.aksw.org/dockevent/types/> .
 @prefix dockevent_actions: <http://ontology.aksw.org/dockevent/actions/> .
-@prefix dockcontainer: <http://ontology.aksw.org/dockcontainer/> .
-@prefix dockcontainer_network: <http://ontology.aksw.org/dockcontainer/network/> .
+@prefix dockcontainer: <http://ontology.aksw.org/dockevent/containers/> .
+@prefix dockcontainer_network: <http://ontology.aksw.org/dockevent/networks/> .
 
 
 dockevent:Event a owl:Class ;

--- a/docs/docker-engine-events/events.owl
+++ b/docs/docker-engine-events/events.owl
@@ -4,8 +4,8 @@
 @prefix dockevent: <http://ontology.aksw.org/dockevent/> .
 @prefix dockevent_types: <http://ontology.aksw.org/dockevent/types/> .
 @prefix dockevent_actions: <http://ontology.aksw.org/dockevent/actions/> .
-@prefix dockcontainer: <http://ontology.aksw.org/dockevent/containers/> .
-@prefix dockcontainer_network: <http://ontology.aksw.org/dockevent/networks/> .
+@prefix dockevent_containers: <http://ontology.aksw.org/dockevent/containers/> .
+@prefix dockevent_networks: <http://ontology.aksw.org/dockevent/networks/> .
 
 
 dockevent:Event a owl:Class ;
@@ -166,6 +166,13 @@ dockevent:containerEnvVar a owl:DatatypeProperty ;
         rdfs:range        xsd:string ;
         rdfs:isDefinedBy  dockevent: ;
         rdfs:label        "event container env var"@en .
+
+dockevent:container a owl:ObjectProperty ;
+        rdfs:comment      "Defines container of an event."@en ;
+        rdfs:domain       dockevent:Event ;
+        rdfs:range        dockevent:Container ;
+        rdfs:isDefinedBy  dockevent: ;
+        rdfs:label        "container"@en .
 
 
 dockevent:Network a owl:Class ;

--- a/docs/docker-engine-events/events.owl
+++ b/docs/docker-engine-events/events.owl
@@ -4,6 +4,8 @@
 @prefix dockevent: <http://ontology.aksw.org/dockevent/> .
 @prefix dockevent_types: <http://ontology.aksw.org/dockevent/types/> .
 @prefix dockevent_actions: <http://ontology.aksw.org/dockevent/actions/> .
+@prefix dockcontainer: <http://ontology.aksw.org/dockcontainer/> .
+@prefix dockcontainer_network: <http://ontology.aksw.org/dockcontainer/network/> .
 
 
 dockevent:Event a owl:Class ;
@@ -130,6 +132,74 @@ dockevent:timeNano a owl:DatatypeProperty ;
         rdfs:range        xsd:int ;
         rdfs:isDefinedBy  dockevent: ;
         rdfs:label        "time nano"@en .
+
+
+dockevent:Container a owl:Class ;
+        rdfs:comment      "Identifies a container inside docker event."@en ;
+        rdfs:isDefinedBy dockevent: ;
+        rdfs:label        "Container"@en .
+
+dockevent:containerId a owl:DatatypeProperty ;
+        rdfs:comment      "An id of a container."@en ;
+        rdfs:domain       dockevent:Container ;
+        rdfs:range        xsd:string ;
+        rdfs:isDefinedBy  dockevent: ;
+        rdfs:label        "event container id"@en .
+
+dockevent:containerName a owl:DatatypeProperty ;
+        rdfs:comment      "A name of a container."@en ;
+        rdfs:domain       dockevent:Container ;
+        rdfs:range        xsd:string ;
+        rdfs:isDefinedBy  dockevent: ;
+        rdfs:label        "event container name"@en .
+
+dockevent:containerLabel a owl:DatatypeProperty ;
+        rdfs:comment      "A label of a container."@en ;
+        rdfs:domain       dockevent:Container ;
+        rdfs:range        xsd:string ;
+        rdfs:isDefinedBy  dockevent: ;
+        rdfs:label        "event container label"@en .
+
+dockevent:containerEnvVar a owl:DatatypeProperty ;
+        rdfs:comment      "An environmental variable of a container."@en ;
+        rdfs:domain       dockevent:Container ;
+        rdfs:range        xsd:string ;
+        rdfs:isDefinedBy  dockevent: ;
+        rdfs:label        "event container env var"@en .
+
+
+dockevent:Network a owl:Class ;
+        rdfs:comment      "Identifies a network for a container."@en ;
+        rdfs:isDefinedBy dockevent: ;
+        rdfs:label        "Network"@en .
+
+dockevent:networkId a owl:DatatypeProperty ;
+        rdfs:comment      "An id for a network."@en ;
+        rdfs:domain       dockevent:Network ;
+        rdfs:range        xsd:string ;
+        rdfs:isDefinedBy  dockevent: ;
+        rdfs:label        "network id"@en .
+
+dockevent:networkName a owl:DatatypeProperty ;
+        rdfs:comment      "A name for a network."@en ;
+        rdfs:domain       dockevent:Network ;
+        rdfs:range        xsd:string ;
+        rdfs:isDefinedBy  dockevent: ;
+        rdfs:label        "network name"@en .
+
+dockevent:networkIp a owl:DatatypeProperty ;
+        rdfs:comment      "Ip address for the network."@en ;
+        rdfs:domain       dockevent:Network ;
+        rdfs:range        xsd:string ;
+        rdfs:isDefinedBy  dockevent: ;
+        rdfs:label        "network IP"@en .
+
+dockevent:network a owl:ObjectProperty ;
+        rdfs:comment      "Defines container network."@en ;
+        rdfs:domain       dockevent:Container ;
+        rdfs:range        dockevent:Network ;
+        rdfs:isDefinedBy  dockevent: ;
+        rdfs:label        "network"@en .
 
 
 dockevent:Actor a owl:Class ;

--- a/muswarmlogger/event2rdf.py
+++ b/muswarmlogger/event2rdf.py
@@ -39,7 +39,7 @@ class Event2RDF(object):
 
         event_id = "%s_%s" % (event_id, _timeNano)
         event_node = self.store.resource("dockevent:%s" % event_id)
-        event_node.add(RDF.type, DOCKEVENT_TYPES.event)
+        event_node.add(RDF.type, DOCKEVENT.Event)
         event_node.add(DOCKEVENT.eventId, Literal(event_id))
         event_node.add(DOCKEVENT.time, Literal(_time))
         event_node.add(DOCKEVENT.timeNano, Literal(_timeNano))
@@ -87,6 +87,7 @@ class Event2RDF(object):
         if container is not None:
             container_id = "%s_%s" % (container["Id"], _timeNano)
             container_node = self.store.resource("dockevent_containers:%s" % container_id)
+            container_node.add(RDF.type, DOCKEVENT.Container)
             container_node.add(DOCKEVENT.networkId, Literal(container["Id"]))
             container_node.add(DOCKEVENT.networkName, Literal(container["Name"]))
             for label, value in container["Config"]["Labels"].items():
@@ -96,6 +97,7 @@ class Event2RDF(object):
             for name, network in container["NetworkSettings"]["Networks"].items():
                 network_id = "%s_%s" % (network["NetworkID"], _timeNano)
                 network_node = self.store.resource("dockevent_networks:%s" % network_id)
+                network_node.add(RDF.type, DOCKEVENT.Network)
                 network_node.add(DOCKEVENT.networkName, Literal(name))
                 network_node.add(DOCKEVENT.networkId, Literal(network["NetworkID"]))
                 network_node.add(DOCKEVENT.networkIp, Literal(network["IPAddress"]))
@@ -107,6 +109,7 @@ class Event2RDF(object):
             actor_id = actor.get("ID", "")
             actor_id = "%s_%s" % (actor_id, _timeNano)
             actor_node = self.store.resource("dockevent_actors:%s" % actor_id)
+            actor_node.add(RDF.type, DOCKEVENT.Actor)
             actor_node.add(DOCKEVENT.actorId, Literal(actor_id, datatype=XSD.dateTime))
             actor_attributes = actor.get("Attributes", "")
             if actor_attributes != "":

--- a/muswarmlogger/event2rdf.py
+++ b/muswarmlogger/event2rdf.py
@@ -8,8 +8,8 @@ DOCKEVENT = Namespace('http://ontology.aksw.org/dockevent/')
 DOCKEVENT_TYPES = Namespace('http://ontology.aksw.org/dockevent/types/')
 DOCKEVENT_ACTIONS = Namespace('http://ontology.aksw.org/dockevent/actions/')
 DOCKEVENT_ACTORS = Namespace('http://ontology.aksw.org/dockevent/actors/')
-DOCKCONTAINER = Namespace('http://ontology.aksw.org/dockcontainer/')
-DOCKCONTAINER_NETWORK = Namespace('http://ontology.aksw.org/dockcontainer/network/')
+DOCKCONTAINER = Namespace('http://ontology.aksw.org/dockevent/containers/')
+DOCKCONTAINER_NETWORK = Namespace('http://ontology.aksw.org/dockevent/networks/')
 
 class Event2RDF(object):
     def __init__(self):


### PR DESCRIPTION
Ontology is updated, modifications in event2rdf:
- New dockevent:Container class
- New dockevent:Network class
- All instances got class information attached (via rdf:type)

Note:
New namespaces are created for instances (i.e. http://ontology.aksw.org/dockevent/networks/ for instances such as http://ontology.aksw.org/dockevent/networks/44f8517e4fda6c5fda79600be34fd004f2b888ab33489d5024b0a7ce5f6d0b8b_1493287305050573423). The ontology elements should stay in http://ontology.aksw.org/dockevent/ namespace (i.e. dockevent:containerId). We can have a separate call on ontology design if necessary.

Tested on 3 node Docker Swarm using following docker-compose:
```
version: "2.1"
services:
  nginx:
    image: nginx
    healthcheck:
      test: ["CMD", "curl", "-f", "http://localhost"]
      interval: 5s
      timeout: 10s
      retries: 3
    networks:
      - outside
    volumes:
      - data:/data

networks:
  outside:
    external:
      name: test
  
volumes:
  data:
```